### PR TITLE
Update the logic-app stretch goal to account for more restricted face-api usage allowance

### DIFF
--- a/alternative_workshop.md
+++ b/alternative_workshop.md
@@ -275,7 +275,9 @@ Without a subscription key we're limited to a throttled connection; if we want t
 
 ## Part 6 (Stretch) - Try out facial recognition
 
-Azure's cognitive services offer many other services, including a facial recognition API. We will set up a new Logic App to catch uploaded images & send them to a Face API instance and we'll store the estimated ages of the subjects.
+> This exercise requires access to the "Code View" of your logic app - check that you can access that for one of your existing apps before starting.
+
+Azure's cognitive services offer many other services, including a facial recognition API. We will set up a new Logic App to catch uploaded images & send them to a Face API instance and we'll store the location of any faces in the image.
 
 You'll need to consider:
 * Where you'll store the images
@@ -307,9 +309,26 @@ https://<your_storage_account_name>.blob.core.windows.net@{triggerBody()?['Path'
 </details>
 </details>
 
+Try running the app now by uploading an image to your blob. Does the run report success?
+
+<details> <summary> Hint: Forbidden </summary>
+
+Microsoft have [tightened access to this API](https://learn.microsoft.com/en-us/legal/cognitive-services/computer-vision/limited-access-identity?context=%2Fazure%2Fcognitive-services%2Fcomputer-vision%2Fcontext%2Fcontext), to prevent potential abuse. However, we _can_ detect faces without applying for permission.
+
+You may need to switch to the Logic App Code View in order to make the change to only request face location, but ensure the `queries` block isn't requesting any blocked information:
+```json
+"queries": {
+    "returnFaceAttributes": "",
+    "returnFaceId": "false",
+    "returnFaceLandmarks": "false"
+}
+```
+
+</details>
+
 Finally, we should do something with this information! For now, we'll just store that information in our table storage. Add a new Table to your Storage Account called "FaceInformation", and update your Logic App to add an entry to that table for each face recognised including:
 * The image name
-* The estimated age of the identified subject
+* The estimated location of the face
 
 Try out your application - upload some photos with & without people in, and see how well it handles it. Do you agree with its assessments?
 

--- a/during_workshop.md
+++ b/during_workshop.md
@@ -132,12 +132,12 @@ Before we worry about hosting the function on Azure itself we are going to test 
 - Run command:  `func start`
 > Note that the Azure Functions tools are only compatible with the 64-bit version of Python. If you see this error `ImportError: cannot import name 'cygrpc'`, you are using a 32-bit version.
 > If you face an issue with `func start` hanging, try running `func start --verbose` for more info. You may find removing the `extensionBundle` section of your `host.json` file fixes it. 
-- Towards the end of the output it should give you a URL. Copy this into a browser and append the query string `?name=<YOUR_NAME>` (so the full URL looks something like `http://localhost:7071/api/HttpEndpoint?name=Alice`)
+- Towards the end of the output it should give you a URL. Copy this into a browser and append the query string `?name=<YOUR_NAME>` (so the full URL looks something like `http://localhost:7071/api/AddSubtitle?name=Alice`)
 - You should hopefully see a message returned from the function
 
 #### Writing Python Code for Azure Functions
 
-Now that we have it running locally, we want to replace the code in the default function with something similar to the dummy code that we are using in our existing application. However, we will change it so we can send the text that we want to translate to it. Change \_\_init\_\_.py to look like the following:
+Now that we have it running locally, we want to replace the code in the default function with something similar to the dummy code that we are using in our existing application. However, we will change it so we can send the text that we want to translate to it. Change function_app.py to look like the following:
 
 ``` Python
 import logging


### PR DESCRIPTION
Due to limited access introduced since we wrote this goal, we can't request default features like whether a face has glasses or where different landmark features are. Instead, we just detect the number and location of faces
Tested in the existing solution in the `M11_Workshop_Example_Solution` RG

Also added a warning note about accessing the Code View - I get a warning when I look at that page (`Starting September 2024, the legacy designer will retire and become unavailable.`) but it seems to be referring to the legacy designer that isn't being used from the Designer View. So not planning to follow up, but should let learners know early if there's an issue

Finally, tweaked a couple of mismatched names due to the V2 functions change